### PR TITLE
Fix readme to include correct instructions for using cobalt to generate OAuth Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ To generate tokens using Cobalt, execute the following command.
 
 ```bash
 git clone https://github.com/imputnet/cobalt
-cd cobalt
-npm install
+cd cobalt/api/src
+npm install -g pnpm
+pnpm install
 npm run token:youtube
 ```
 


### PR DESCRIPTION
Old instructions:
```
git clone https://github.com/imputnet/cobalt
cd cobalt
npm install
npm run token:youtube
```

Updated instructions from [here](https://github.com/imputnet/cobalt/blob/main/docs/run-an-instance.md):
```
git clone https://github.com/imputnet/cobalt
cd cobalt/api/src
npm install -g pnpm
pnpm install
npm run token:youtube
```